### PR TITLE
chore(commitlint): remove custom body-max-line-length rule

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,9 +1,0 @@
-export default {
-  extends: ['@commitlint/config-conventional'],
-  /*
-   * Any rules defined here will override rules from @commitlint/config-conventional
-   */
-  rules: {
-    'body-max-line-length': [2, 'always', 200],
-  },
-};


### PR DESCRIPTION
Remove the custom body-max-line-length rule from the commitlint 
configuration to streamline commit message enforcement and align 
with conventional practices. This change simplifies the config by 
relying on the standard rule set.