### PR TITLE
fix: update Terraform required version to 1.3

### DIFF
--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -15,5 +15,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Updates the required Terraform version from 1.1.9 to 1.3 in both 
provider.tf and providers.tf to ensure compatibility with the 
latest features and improvements in Terraform 1.3.