### PR TITLE
refactor: rename module and update README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,4 @@
-# terraform-aws-k8s-github-runners
+# terraform-aws-k8s-addons-github-runners-controller
 
 A terraform module which provides
 the [Github Action Runner controller](https://github.com/actions-runner-controller/actions-runner-controller)
-
-## How to update the module to a new version of the action runners controller
-
-```shell
-helm repo add actions-runner-controller https://actions-runner-controller.github.io/actions-runner-controller
-helm repo update actions-runner-controller
-```
-
-Then template the chart to file
-```shell
-helm template actions-runner-controller actions-runner-controller/actions-runner-controller \
-  -n actions-runner-system \
-  --include-crds \
-  -n actions-runner-system \
-  --values values.yaml >| manifests/actions-runner-controller.yaml
-```
-
-Check the changes and if everything looks correct, commit, push and PR.
-
-## Releasing
-Make sure to update the `version` (in `module_version.tf`) for the addon to match the planned tag/release version before
-tagging the commit.
-
-...or use the targets in the `Makefile`

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "addons" {
     {
       content = local.yaml
       version = local.version
-      name    = "github-runners"
+      name    = "github-runners-controller"
     }
   ]
 }


### PR DESCRIPTION
Updates the README to reflect the new module name 
from `terraform-aws-k8s-github-runners` to 
`terraform-aws-k8s-addons-github-runners-controller`. 
Changes the output name in `outputs.tf` to match 
the updated naming conventions for clarity and 
consistency within the project. Removes outdated 
instructions to streamline the documentation.